### PR TITLE
Allow users to set which levels the journalhook fires for

### DIFF
--- a/journalhook.go
+++ b/journalhook.go
@@ -9,7 +9,9 @@ import (
 	"github.com/coreos/go-systemd/journal"
 )
 
-type JournalHook struct{}
+type JournalHook struct {
+	LogrusLevels []logrus.Level
+}
 
 var (
 	severityMap = map[logrus.Level]journal.Priority{
@@ -64,14 +66,18 @@ func (hook *JournalHook) Fire(entry *logrus.Entry) error {
 
 // `Levels()` returns a slice of `Levels` the hook is fired for.
 func (hook *JournalHook) Levels() []logrus.Level {
-	return []logrus.Level{
-		logrus.PanicLevel,
-		logrus.FatalLevel,
-		logrus.ErrorLevel,
-		logrus.WarnLevel,
-		logrus.InfoLevel,
-		logrus.DebugLevel,
+	if len(hook.LogrusLevels) == 0 {
+		return []logrus.Level{
+			logrus.PanicLevel,
+			logrus.FatalLevel,
+			logrus.ErrorLevel,
+			logrus.WarnLevel,
+			logrus.InfoLevel,
+			logrus.DebugLevel,
+		}
 	}
+
+	return hook.LogrusLevels
 }
 
 // Adds the Journal hook if journal is enabled


### PR DESCRIPTION
We've run into an issue using this internally where we're logging too much for journald to handle normally, so it's dropping messages because of rate limiting. So, it would be nice to log only errors and above.

This should maintain backwards compatibility, defaulting to all levels if none are specified... and doesn't require making a constructor.