### PR TITLE
Logrus org name changed case

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ If you'd like not to do that, it's as easy as:
 
 import (
     "github.com/wercker/journalhook"
-    "github.com/Sirupsen/logrus"
+    "github.com/sirupsen/logrus"
 )
 
 logrus.AddHook(&journalhook.JournalHook{})

--- a/glide.yaml
+++ b/glide.yaml
@@ -5,5 +5,5 @@
 package: main
 
 import:
-    - package: github.com/Sirupsen/logrus
+    - package: github.com/sirupsen/logrus
     - package: github.com/coreos/go-systemd/journal

--- a/journalhook.go
+++ b/journalhook.go
@@ -5,8 +5,8 @@ import (
 	"io/ioutil"
 	"strings"
 
-	logrus "github.com/Sirupsen/logrus"
 	"github.com/coreos/go-systemd/journal"
+	logrus "github.com/sirupsen/logrus"
 )
 
 type JournalHook struct{}


### PR DESCRIPTION
This change makes the imports and documentation use the new lowercase import path.